### PR TITLE
Fixed link to Markdown documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # NodeBB Markdown Parser
 
-This NodeBB plugin is a parser that allows users to write posts using [Markdown](daringfireball.net/projects/markdown/).
+This NodeBB plugin is a parser that allows users to write posts using [Markdown](https://daringfireball.net/projects/markdown/).
 
 To customise options for the parser, please consult the "Markdown" page in the administration panel, under the "Plugins" heading.
 


### PR DESCRIPTION
Without a fully qualified URL, the link will start from the current repository