### PR TITLE
Update Chinese Simplified translation

### DIFF
--- a/public/languages/zh_CN/markdown.json
+++ b/public/languages/zh_CN/markdown.json
@@ -2,10 +2,10 @@
 	"bold": "粗体字",
 	"italic": "斜体字",
 	"list_item": "列表",
-	"strikethrough_text": "strikethrough text",
+	"strikethrough_text": "删除线",
 	"link_text": "链接文本",
 	"link_url": "链接地址",
-	"picture_text": "alt text",
-	"picture_url": "image url",
-	"help_text": "This forum is powered by Markdown. For full documentation, [click here](http://commonmark.org/help/)"
+	"picture_text": "替代文字",
+	"picture_url": "图片地址",
+	"help_text": "该论坛使用 Markdown 语法。[点此查看](http://commonmark.org/help/) 语法说明。"
 }


### PR DESCRIPTION
The `alt text`, `image url` and help text have been translate to Chinese.

I also want to change the help site to a Chinese version, but I cannot find a proper one. I will leave this same as English version for now.