### PR TITLE
fix parent require method using absolute path with nbbRequire

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,14 +6,19 @@ var path = require('path');
 var url = require('url');
 var async = require('async');
 
-var	meta = module.parent.require('./meta');
-var nconf = module.parent.require('nconf');
-var translator = module.parent.require('../public/src/modules/translator');
 var winston = module.parent.require('winston');
+var nconf = module.parent.require('nconf');
+
+var nbbRequire = require('./lib/nbbRequire');
+
+var	meta = nbbRequire('./src/meta');
+var translator = nbbRequire('./public/src/modules/translator');
+var SocketPlugins = nbbRequire('./src/socket.io/plugins');
+
+SocketPlugins.markdown = require('./websockets');
+
 var plugins = module.parent.exports;
 
-var SocketPlugins = module.parent.require('../src/socket.io/plugins');
-SocketPlugins.markdown = require('./websockets');
 
 var	parser;
 

--- a/lib/nbbRequire.js
+++ b/lib/nbbRequire.js
@@ -1,0 +1,6 @@
+var path = require('path');
+var nconf = require.main.require('nconf');
+
+module.exports = modulePath => {
+	return require(path.join(nconf.get('base_dir'), modulePath));
+};

--- a/websockets.js
+++ b/websockets.js
@@ -1,9 +1,12 @@
 'use strict';
 
 var async = require('async');
-var privileges = module.parent.parent.require('./privileges');
-var SocketPosts = module.parent.parent.require('./socket.io/posts');
-var posts = module.parent.parent.require('./posts');
+
+var nbbRequire = require('./lib/nbbRequire');
+
+var privileges = nbbRequire('./src/privileges');
+var SocketPosts = nbbRequire('./src/socket.io/posts');
+var posts = nbbRequire('./src/posts');
 
 module.exports.checkbox = {
 	edit: function (socket, data, callback) {


### PR DESCRIPTION
This fix the warning in NodeBB 1.10.* "warn: [plugins/require] please update module.parent.require" for linked npm package (development mode) and for npm registry imported package (classic install)