### PR TITLE
limiting `dir=auto` to paragraph's open tags only

### DIFF
--- a/index.js
+++ b/index.js
@@ -243,7 +243,9 @@ var Markdown = {
 		parser.use((md) => {
 			md.core.ruler.before('linkify', 'autodir', (state) => {
 				state.tokens.forEach((token) => {
-					token.attrJoin('dir', 'auto');
+					if (token.type === 'paragraph_open') {
+						token.attrJoin('dir', 'auto');
+					}
 				});
 			});
 		});


### PR DESCRIPTION
related to https://github.com/julianlam/nodebb-plugin-markdown/pull/105