### PR TITLE
Add markdown-it-multimd-table, resolves #113

### DIFF
--- a/index.js
+++ b/index.js
@@ -238,7 +238,9 @@ var Markdown = {
 	updateSanitizeConfig: async (config) => {
 		config.allowedTags.push('input');
 		config.allowedAttributes.input = ['type', 'checked'];
-
+		config.allowedAttributes.th.push('colspan', 'rowspan');
+		config.allowedAttributes.td.push('colspan', 'rowspan');
+		
 		return config;
 	},
 

--- a/index.js
+++ b/index.js
@@ -81,6 +81,7 @@ var Markdown = {
 			nofollow: true,
 			allowRTLO: false,
 			checkboxes: true,
+			multimdTables: true,
 		};
 
 		meta.settings.get('markdown', function (err, options) {
@@ -248,6 +249,14 @@ var Markdown = {
 				divWrap: true,
 				divClass: 'plugin-markdown',
 			});
+		}
+
+		if (Markdown.config.multimdTables) {
+			parser.use(require('markdown-it-multimd-table'), {
+				multiline:  true,
+				rowspan:    true,
+				headerless: true,
+			})
 		}
 
 		parser.use((md) => {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "async": "^2",
     "highlight.js": "9.14.2",
     "markdown-it": "^10.0.0",
-    "markdown-it-checkbox": "^1.1.0"
+    "markdown-it-checkbox": "^1.1.0",
+    "markdown-it-multimd-table": "^4.0.1"
   },
   "nbbpm": {
     "compatibility": "^1.6.0"

--- a/public/templates/admin/plugins/markdown.tpl
+++ b/public/templates/admin/plugins/markdown.tpl
@@ -26,7 +26,7 @@
 								</label>
 							</div>
 							<div class="form-group">
-								<label for="checkboxes">
+								<label for="multimdTables">
 									<input type="checkbox" name="multimdTables" id="multimdTables" />
 									Allow advanced table syntax
 								</label>

--- a/public/templates/admin/plugins/markdown.tpl
+++ b/public/templates/admin/plugins/markdown.tpl
@@ -25,6 +25,12 @@
 									Enable smartypants and other sweet transforms (e.g. <code>(c)</code> &rarr; <code>&copy;</code>)
 								</label>
 							</div>
+							<div class="form-group">
+								<label for="checkboxes">
+									<input type="checkbox" name="multimdTables" id="multimdTables" />
+									Allow advanced table syntax
+								</label>
+							</div>
 						</div>
 						<div class="col-lg-6">
 							<div class="form-group">


### PR DESCRIPTION
resolves #113 
Added markdown-it-multimd-table to package.json, and created a setting to enable or disable it (`multimdTables`). I also had to add `colspan` and `rowspan` as attributes to `th` and `td` in sanitizer config, because otherwise they were filtered out.
A checkbox to toggle this setting was also added to ACP - the decision to add it to the first of the two available columns was one of aesthetics since the other way seems a bit... unbalanced:
![Unbalanced columns](https://i.imgur.com/DJRax75.png)
The way it looks now:
![More balanced columns](https://i.imgur.com/AWQMqf2.png)

Also, I decided against separate settings for options included in markdown-it-multimd-table, that is:
* multiline
* rowspan
* headerless tables

And set them all to `true` to simplify the configuration. If you believe it to be a bad idea, I'll add these settings separately :)

Quick test using examples from multimd-table readme and the multiline table from the community post confirms that the plugin works as intended:
![working advanced tables](https://i.imgur.com/FpI5xYM.png)
