### PR TITLE
Add ol start attribute to sanitize config, fixes #115

### DIFF
--- a/index.js
+++ b/index.js
@@ -237,7 +237,7 @@ var Markdown = {
 	updateSanitizeConfig: async (config) => {
 		config.allowedTags.push('input');
 		config.allowedAttributes.input = ['type', 'checked'];
-		config.allowedAttributes.ol.push('start')
+		config.allowedAttributes.ol.push('start');
 
 		return config;
 	},

--- a/index.js
+++ b/index.js
@@ -237,6 +237,7 @@ var Markdown = {
 	updateSanitizeConfig: async (config) => {
 		config.allowedTags.push('input');
 		config.allowedAttributes.input = ['type', 'checked'];
+		config.allowedAttributes.ol.push('start')
 
 		return config;
 	},


### PR DESCRIPTION
fixes #115
Turns out that default sanitize-html config doesn't have <ol> start attribute enabled, so all numbered lists start at 1 because the attribute that modifies that is removed.

I think I'll also try to find some other bugs like that, because quite possibly the inclusion of a sanitizer in core NodeBB broke some other markdown features by removing attributes.